### PR TITLE
Fix for parsing real pins

### DIFF
--- a/grammars/verilog.rb
+++ b/grammars/verilog.rb
@@ -7375,9 +7375,9 @@ module OrigenVerilog
       module NetType0
         def to_ast
           if text_value == "wire real" || text_value == 'wreal'
-            "real"
+            n(:real)
           else
-            text_value
+            n(text_value.to_sym)
           end
         end
       end

--- a/grammars/verilog.treetop
+++ b/grammars/verilog.treetop
@@ -595,9 +595,9 @@ module OrigenVerilog
         "uwire" / "wire" / "wand" / "wor") {
           def to_ast
             if text_value == "wire real" || text_value == 'wreal'
-              "real"
+              n(:real)
             else
-              text_value
+              n(text_value.to_sym)
             end
           end
         }

--- a/lib/origen_verilog/verilog/node.rb
+++ b/lib/origen_verilog/verilog/node.rb
@@ -60,8 +60,7 @@ module OrigenVerilog
           wreals = self.wreals.map { |n| n.to_a.last }
           subset = []
           pins.each do |pin|
-            attrs = pin.to_a
-            if attrs.include?('real') || wreals.include?(attrs.last)
+            if pin.find(:real) || wreals.include?(pin.to_a.last)
               subset << pin if options[:analog]
             else
               subset << pin if options[:digital]
@@ -82,7 +81,7 @@ module OrigenVerilog
       def wreals
         find_all(:non_port_module_item)
           .map { |item| item.find(:net_declaration) }
-          .select { |net| net.to_a.include?('real') }
+          .select { |net| net.find(:real) }
       end
 
       # Evaluates all functions and turns numbers into Ruby literals

--- a/spec/dut_spec.rb
+++ b/spec/dut_spec.rb
@@ -108,5 +108,6 @@ describe 'Parsing a Verilog file into an Origen DUT model' do
     dut.pin(:vdd).type.should == :analog
     dut.pin(:vddc).type.should == :analog
     dut.pin(:vddf).type.should == :analog
+    dut.has_pin?(:real).should == false
   end
 end


### PR DESCRIPTION
Changes the AST modeling of something like:

~~~
input real my_signal;
~~~

So that the real attribute is captured as a node rather than a string, this prevents "real" from being mis-interpreted as a pin name downstream.