### PR TITLE
Some pin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ ast.modules.first.to_top_level # Creates dut
 dut.pins.size   # => 60 (for example, depends on what was in the Verilog source)
 ~~~
 
+The pin types OrigenVerilog comes up with can be overridden, either with `Strings`,
+which much be an exact match, or using `Regexp`s. These are be given as a `Hash`
+whose keys are pin names or regexes to try and the value are the overridden type.
+
+~~~ruby
+# Creates dut with pin types overridden, forcing all pins matching /vdd/ to be digital
+# and 'enable' to be analog.
+ast.modules.first.to_top_level(forced_pin_types: {'enable' => :analog, /vdd/ => :digital})
+~~~
+
+*Important:* If a pin matches multiple keys of the input, the first match will
+be used. Care must be taken if overlapping regexes or pin names are given.
+
+Pin roles are also given as an array of regexes or pin names to match. Pin roles indicate whether a given pin
+should be added as a `power pin`, `ground pin`, 'virtual pin`, or `other pin`.
+
+~~~ruby
+# Creates dut with power pins matching /vdd/, ground pins matching /gnd/,
+# 'pta1' and 'pta2' and other pins, and 'vt' as a virtual pin
+dut_ast.to_top_level(power_pins: [/vdd/], ground_pins: [/gnd/], other_pins: ['pta1', 'pta2'], virtual_pins: ['vt'])
+~~~
+
 Additional files can be given up front, for example a parameters file:
 
 ~~~ruby

--- a/lib/origen_verilog/top_level.rb
+++ b/lib/origen_verilog/top_level.rb
@@ -10,7 +10,7 @@ module OrigenVerilog
       @options = options
 
       pins = options[:ast].pins(digital: true).map { |p| [p, :digital] }.to_h
-      pins.merge(options[:ast].pins(analog: true).map { |p| [p, :analog] }.to_h)
+      pins.merge!(options[:ast].pins(analog: true).map { |p| [p, :analog] }.to_h)
 
       # Override any pin types from the user
       if options[:forced_pin_types]

--- a/lib/origen_verilog/top_level.rb
+++ b/lib/origen_verilog/top_level.rb
@@ -3,15 +3,45 @@ module OrigenVerilog
     include Origen::TopLevel
 
     attr_reader :name
+    attr_reader :options
 
     def initialize(options = {})
       @name = options[:ast].to_a[0]
+      @options = options
 
-      options[:ast].pins(digital: true).each { |n| _add_pin_(n, :digital) }
-      options[:ast].pins(analog: true).each { |n| _add_pin_(n, :analog) }
+      pins = options[:ast].pins(digital: true).map { |p| [p, :digital] }.to_h
+      pins.merge(options[:ast].pins(analog: true).map { |p| [p, :analog] }.to_h)
+
+      # Override any pin types from the user
+      if options[:forced_pin_types]
+        pins = pins.map do |pin, type|
+          matched = options[:forced_pin_types].any? do |matcher, forced_type|
+            if matcher.is_a?(Regexp) && pin.value =~ matcher
+              type = forced_type
+              true
+            elsif pin.value == matcher
+              type = forced_type
+              true
+            end
+          end
+          matched ? [pin, type] : [pin, type]
+        end.to_h
+      end
+      pins.each { |n, type| _add_pin_(n, type) }
     end
 
     private
+
+    def pin_role?(role, pin)
+      (options[role] || []).each do |matcher|
+        if matcher.is_a?(Regexp)
+          return true if pin.to_s =~ matcher
+        else
+          return true if pin.to_s == matcher
+        end
+      end
+      false
+    end
 
     def _add_pin_(node, type)
       node = node.evaluate  # Resolve any functions in the ranges
@@ -31,7 +61,18 @@ module OrigenVerilog
       end
       n = node.to_a.dup
       while n.last.is_a?(String)
-        add_pin n.pop.to_sym, direction: direction, size: size, offset: offset, type: type
+        pin = n.pop
+        if pin_role?(:ground_pins, pin)
+          add_ground_pin pin.to_sym, direction: direction, size: size, offset: offset, type: type
+        elsif pin_role?(:power_pins, pin)
+          add_power_pin pin.to_sym, direction: direction, size: size, offset: offset, type: type
+        elsif pin_role?(:virtual_pins, pin)
+          add_virtual_pin pin.to_sym, direction: direction, size: size, offset: offset, type: type
+        elsif pin_role?(:other_pins, pin)
+          add_other_pin pin.to_sym, direction: direction, size: size, offset: offset, type: type
+        else
+          add_pin pin.to_sym, direction: direction, size: size, offset: offset, type: type
+        end
       end
     end
   end

--- a/lib/origen_verilog/verilog/node.rb
+++ b/lib/origen_verilog/verilog/node.rb
@@ -58,6 +58,9 @@ module OrigenVerilog
         pins = find_all(:input_declaration, :output_declaration, :inout_declaration)
         if options[:analog] || options[:digital]
           wreals = self.wreals.map { |n| n.to_a.last }
+          puts "wreals".green
+          puts wreals
+          #exit!
           subset = []
           pins.each do |pin|
             if pin.find(:real) || wreals.include?(pin.to_a.last)
@@ -98,7 +101,8 @@ module OrigenVerilog
         unless type == :module_declaration
           fail 'Currently only modules support the to_model method'
         end
-        Origen.target.temporary = -> { TopLevel.new(ast: self, **options) }
+        options[:ast] = self
+        Origen.target.temporary = -> { TopLevel.new(options) }
         Origen.load_target
       end
     end

--- a/lib/origen_verilog/verilog/node.rb
+++ b/lib/origen_verilog/verilog/node.rb
@@ -94,11 +94,11 @@ module OrigenVerilog
       #
       # This will re-load the Origen target with the resultant model instantiated
       # as the global dut object.
-      def to_top_level
+      def to_top_level(options = {})
         unless type == :module_declaration
           fail 'Currently only modules support the to_model method'
         end
-        Origen.target.temporary = -> { TopLevel.new(ast: self) }
+        Origen.target.temporary = -> { TopLevel.new(ast: self, **options) }
         Origen.load_target
       end
     end

--- a/lib/origen_verilog/verilog/node.rb
+++ b/lib/origen_verilog/verilog/node.rb
@@ -58,9 +58,6 @@ module OrigenVerilog
         pins = find_all(:input_declaration, :output_declaration, :inout_declaration)
         if options[:analog] || options[:digital]
           wreals = self.wreals.map { |n| n.to_a.last }
-          puts "wreals".green
-          puts wreals
-          #exit!
           subset = []
           pins.each do |pin|
             if pin.find(:real) || wreals.include?(pin.to_a.last)

--- a/spec/dut_spec.rb
+++ b/spec/dut_spec.rb
@@ -110,4 +110,50 @@ describe 'Parsing a Verilog file into an Origen DUT model' do
     dut.pin(:vddf).type.should == :analog
     dut.has_pin?(:real).should == false
   end
+  
+  it 'can override toplevel pin roles' do
+    options = {}
+    options[:source_dirs] = ["#{Origen.root}/examples/dut/params"]
+
+    begin
+      ast = OrigenVerilog.parse_file("#{Origen.root}/examples/dut/dut.v", options)
+    rescue SystemExit
+    end
+
+    dut_ast = ast.top_level_modules.first
+
+    dut_ast.to_top_level(power_pins: [/vdd/])
+
+    dut.should be
+
+    dut.pin(:enable).type.should == :digital
+    dut.has_pin?(:vdd).should == false
+    dut.has_pin?(:vddc).should == false
+    dut.has_pin?(:vddf).should == false
+
+    dut.has_power_pin?(:vdd)
+    dut.has_power_pin?(:vddc)
+    dut.has_power_pin?(:vddf)
+  end
+  
+  it 'can override toplevel pin types' do
+    options = {}
+    options[:source_dirs] = ["#{Origen.root}/examples/dut/params"]
+
+    begin
+      ast = OrigenVerilog.parse_file("#{Origen.root}/examples/dut/dut.v", options)
+    rescue SystemExit
+    end
+
+    dut_ast = ast.top_level_modules.first
+
+    dut_ast.to_top_level(forced_pin_types: {'enable' => :analog, /vdd/ => :digital})
+
+    dut.should be
+
+    dut.pin(:enable).type.should == :analog
+    dut.pin(:vdd).type.should == :digital
+    dut.pin(:vddc).type.should == :digital
+    dut.pin(:vddf).type.should == :digital
+  end
 end


### PR DESCRIPTION
Added some options to override pin types (analog/digital) and pin roles (ground, power, etc.) during `to_top_level`.  I use this in OrigenSim to generate a toplevel `.rb` file requiring less post-processing. A separate PR for OrigenSim will use this. 